### PR TITLE
Add option value to selection box trigger change to select the option.

### DIFF
--- a/src/jquery.selectionBox.js
+++ b/src/jquery.selectionBox.js
@@ -86,7 +86,7 @@
 
         selectOption: function(i) {
             this.$el.children().eq(i).attr('selected', true);
-            this.$el.trigger('change');
+            this.$el.val(this.$el.children().eq(i).text()).trigger('change');
         },
 
         showList: function() {


### PR DESCRIPTION
The addition of the option value selects the option and makes sure the event target is the selected option. Without the option value, selecting an option that has been previously selected will not return the correct event target.
